### PR TITLE
Fix Chris Voss name typo

### DIFF
--- a/docs/Quotes.md
+++ b/docs/Quotes.md
@@ -14,7 +14,7 @@
 * Discipline gives you choices in life  
 * **Every NO gets you closer to a YES**  
 * **Everyone wants to feel (1) safe and secure and (2) in control**  
-* Negotiation… is nothing more than communication with results. \~ Chriss Voss  
+* Negotiation… is nothing more than communication with results. \~ Chris Voss  
 * Use What and How, not Why, while negotiating or discussing a topic  
 * **How to make a decision:**  
   * Choose  


### PR DESCRIPTION
## Summary
- fix Chris Voss spelling in `docs/Quotes.md`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest` *(fails to import twilio)*

------
https://chatgpt.com/codex/tasks/task_e_683f42852bc88325879d0e115b0360ca