### PR TITLE
Allow optional contact fields in add_subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,10 @@ python send_email.py test@example.com
 # Send a test SMS
 python send_sms.py +1234567890
 
-# Add a new subscriber
-python add_subscriber.py --email=user@example.com --phone=+1234567890
+# Add a new subscriber (email or phone is sufficient)
+python add_subscriber.py user@example.com
+# Or using a phone number only
+python add_subscriber.py "" +1234567890
 
 # View recent quotes
 python get_recent_quotes.py

--- a/add_subscriber.py
+++ b/add_subscriber.py
@@ -64,8 +64,12 @@ def add_subscriber(email=None, phone=None, morning=True, evening=True, categorie
 
 if __name__ == "__main__":
     # This script is meant to be called from Node.js
-    if len(sys.argv) < 3:
-        print(json.dumps({"success": False, "message": "Not enough arguments provided"}))
+    if len(sys.argv) < 2:
+        usage_msg = (
+            "Usage: python add_subscriber.py <email> <phone> [morning] "
+            "[evening] [categories] - either email or phone is required"
+        )
+        print(json.dumps({"success": False, "message": usage_msg}))
         sys.exit(1)
         
     # Get arguments


### PR DESCRIPTION
## Summary
- relax CLI checks in `add_subscriber.py` so either email or phone is acceptable
- document optional contact information in README

## Testing
- `python3 -m py_compile add_subscriber.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f430e44f48325a57c70f352743104