### PR TITLE
Add unittest for SMS sending

### DIFF
--- a/test_sms.py
+++ b/test_sms.py
@@ -1,21 +1,50 @@
-#!/usr/bin/env python3
-import sys
-from send_sms import test_sms_delivery
-from logger import get_logger
+import os
+import unittest
+from unittest.mock import patch, MagicMock
 
-logger = get_logger("test_sms")
+import send_sms
 
-if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Usage: python test_sms.py <phone_number>")
-        sys.exit(1)
-    
-    phone_number = sys.argv[1]
-    print(f"Sending test SMS to {phone_number}")
-    
-    result = test_sms_delivery(phone_number)
-    
-    if result:
-        print("Test SMS sent successfully!")
-    else:
-        print("Failed to send test SMS. Check logs for details.")
+class SendSMSTestCase(unittest.TestCase):
+    @patch('send_sms.Client')
+    def test_send_quote_sms_success(self, mock_client_cls):
+        # Setup Twilio credentials
+        creds = {
+            'TWILIO_ACCOUNT_SID': 'AC123',
+            'TWILIO_AUTH_TOKEN': 'token',
+            'TWILIO_PHONE_NUMBER': '+10000000000',
+        }
+        with patch.dict(os.environ, creds, clear=True):
+            mock_client = MagicMock()
+            mock_message = MagicMock(sid='SM123')
+            mock_client.messages.create.return_value = mock_message
+            mock_client_cls.return_value = mock_client
+
+            result = send_sms.send_quote_sms(
+                to_number='+15555555555',
+                quote_text='hello',
+                quote_author='author',
+                category='general'
+            )
+
+            self.assertTrue(result)
+            mock_client.messages.create.assert_called_once_with(
+                body=send_sms.create_sms_template('hello', 'author', 'general'),
+                from_='+10000000000',
+                to='+15555555555'
+            )
+
+    @patch('send_sms.send_quote_sms')
+    def test_test_sms_delivery_uses_send_quote_sms(self, mock_send):
+        mock_send.return_value = True
+        number = '+15550001111'
+        result = send_sms.test_sms_delivery(number)
+
+        mock_send.assert_called_once_with(
+            to_number=number,
+            quote_text="This is a test quote to verify SMS delivery.",
+            quote_author="Daily Quote Sender"
+        )
+        self.assertTrue(result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- convert `test_sms.py` to unittest test cases
- mock Twilio client so SMS tests don't hit the network
- verify that `test_sms_delivery` invokes `send_quote_sms` correctly and `send_quote_sms` returns `True` on success

## Testing
- `python -m unittest test_sms.py -v`

------
https://chatgpt.com/codex/tasks/task_e_683f43b38cbc83258617b05d93bdd08e